### PR TITLE
Update Readme file to reflect the newest changes in `if let` syntax introduced in Swift 5.7

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -654,6 +654,14 @@ Use optional binding when it's more convenient to unwrap once and perform multip
 if let textContainer = textContainer {
   // do many things with textContainer
 }
+
+```
+**Notes:** Swift 5.7 introduced new shorthand syntax for unwrapping optionals into shadowed variables:
+
+```swift
+if let textContainer {
+  // do many things with textContainer
+}
 ```
 
 When naming optional variables and properties, avoid naming them like `optionalString` or `maybeView` since their optional-ness is already in the type declaration.


### PR DESCRIPTION
I believe we need an update of 'if let' syntax regarding new Swift 5.7 release

https://www.swift.org/blog/swift-5.7-released/
https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md
