### PR TITLE
add attributes rule option

### DIFF
--- a/com.raywenderlich.swiftlint.yml
+++ b/com.raywenderlich.swiftlint.yml
@@ -69,6 +69,7 @@ attributes:
     - "@IBAction"
     - "@NSManaged"
     - "@objc"
+  attributes_with_arguments_always_on_line_above: false
 
 force_cast: warning
 force_try: warning


### PR DESCRIPTION
See issue https://github.com/kodecocodes/swift-style-guide/issues/365

The SwiftLint `attributes` rule states "Attributes should be on their own lines in functions and types, but on the same line as variables and imports"

But it flags property wrapper lines like these with warnings, even though they are not functions or types:

```swift
@AppStorage("editorFontSize") var editorFontSize: Double = 14
@SceneStorage("windowTheme") var windowTheme = "dark"
@Environment(\.dismiss) var dismiss
```

Adding this option to the `attributes` rule solves this: `attributes_with_arguments_always_on_line_above: false`
